### PR TITLE
Wire Gone State

### DIFF
--- a/operator/controllers/actionsrunner/wire/collection.go
+++ b/operator/controllers/actionsrunner/wire/collection.go
@@ -54,7 +54,7 @@ func (c *Collection) WireFor(ctx context.Context, log logr.Logger, actionsRunner
 		Name:      actionsRunner.GetName(),
 	}
 
-	if wire, ok := c.wireRegistry[namespacedName]; ok {
+	if wire, ok := c.wireRegistry[namespacedName]; ok && !wire.gone {
 		return wire, nil
 	}
 


### PR DESCRIPTION
Create a gone state that flags the wire instance as being unusable, allowing another wire for the ActionsRunner to be instantiated. This is useful when the ADO access token used by the wire is not valid anymore and another one needs to be issued.