### PR TITLE
Change Default Metrics Address

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -47,7 +47,7 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-addr", ":9100", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")


### PR DESCRIPTION
Set `9100` as the new default port for the Prometheus exporter.