### PR TITLE
binfmt_misc daemonset

### DIFF
--- a/dind/daemonset.yaml
+++ b/dind/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
           image: multiarch/qemu-user-static
           args:
             - --reset
-            - -p
+            - --persistent
             - 'yes'
           resources:
             requests:

--- a/dind/daemonset.yaml
+++ b/dind/daemonset.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: kube-actions
+  name: binfmt-misc
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-actions
+      app.kubernetes.io/component: binfmt-misc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-actions
+        app.kubernetes.io/component: binfmt-misc
+    spec:
+      initContainers:
+        - name: register
+          image: multiarch/qemu-user-static
+          args:
+            - --reset
+            - -p
+            - 'yes'
+          resources:
+            requests:
+              cpu: 2m
+              memory: 8Mi
+          securityContext:
+            privileged: true
+      containers:
+        - name: pause
+          image: k8s.gcr.io/pause
+          resources:
+            limits:
+              cpu: 2m
+              memory: 8Mi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64


### PR DESCRIPTION
This DaemonSet registers qemu-user-static binaries on binfmt_misc to allow multi-arch Docker images to be built.