### PR TITLE
Create Job Recovery Procedure

### DIFF
--- a/operator/controllers/actionsrunner/consumer.go
+++ b/operator/controllers/actionsrunner/consumer.go
@@ -105,7 +105,7 @@ func (c *Consumer) onJobCancellation(ctx context.Context, ack <-chan struct{}, m
 		return err
 	}
 
-	if err := c.Delete(ctx, actionsRunnerJob, deleteOpts...); err != nil {
+	if err := c.Delete(ctx, actionsRunnerJob, deleteOpts...); client.IgnoreNotFound(err) != nil {
 		c.Log.Error(err, "c.Delete")
 	}
 

--- a/operator/controllers/actionsrunner/facades/ado.go
+++ b/operator/controllers/actionsrunner/facades/ado.go
@@ -40,7 +40,7 @@ import (
 var (
 	agentNameTemplate = "KA %v %v"
 
-	agentVersion = "2.273.4"
+	agentVersion = "2.273.5"
 
 	agentLabelsBase = []string{
 		"self-hosted",

--- a/operator/controllers/actionsrunner/util/converters.go
+++ b/operator/controllers/actionsrunner/util/converters.go
@@ -443,11 +443,6 @@ func addDockerCapability(job *batchv1.Job) {
 	podSpec.Containers = append(podSpec.Containers, corev1.Container{
 		Name:  "dind",
 		Image: fmt.Sprintf("%s:%s%s", dindImageName, dindImageVersion, dindImageVariant),
-		Args: []string{
-			"--add-runtime", "crun=/usr/local/bin/crun",
-			"--default-runtime", "crun",
-			"--experimental",
-		},
 		Env: []corev1.EnvVar{
 			corev1.EnvVar{
 				Name:  "DOCKER_TLS_CERTDIR",

--- a/operator/controllers/actionsrunner/util/converters.go
+++ b/operator/controllers/actionsrunner/util/converters.go
@@ -335,8 +335,8 @@ func ToJob(actionsRunner *inlocov1alpha1.ActionsRunner, actionsRunnerJob *inloco
 								},
 								corev1.VolumeMount{
 									Name:      "persistent-volume-claim",
-									MountPath: "/home",
-									SubPath:   "home",
+									MountPath: "/home/user",
+									SubPath:   "user",
 								},
 							},
 							ImagePullPolicy: corev1.PullAlways,

--- a/operator/controllers/actionsrunner/watcher.go
+++ b/operator/controllers/actionsrunner/watcher.go
@@ -92,6 +92,16 @@ func (wc *WatcherCollection) watch(ctx context.Context, log logr.Logger, actions
 
 	log.Info("Job Completed")
 
+	var job batchv1.Job
+	if err := wc.Get(ctx, objectKey, &job); client.IgnoreNotFound(err) != nil {
+		log.Error(err, "wc.Get")
+	}
+
+	if job.Status.Failed > 0 {
+		log.Info("Recovering from Failed Job")
+		time.Sleep(time.Minute)
+	}
+
 	if err := wc.Delete(ctx, actionsRunnerJob, deleteOpts...); err != nil {
 		log.Error(err, "wc.Delete")
 	}


### PR DESCRIPTION
- Sleep for 1min after job failure
- Update agentVersion to `2.273.5`
- Remap PVC mount from `/home` to `/home/user`
- Remove crun and experimental related args from runner container
- Ignore not-found error on ActionsRunnerJob deletion