### PR TITLE
Use GCR as Registry Mirror

### DIFF
--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -21,6 +21,6 @@ USER rootless
 
 ENV DOCKERD_ROOTLESS_ROOTLESSKIT_NET slirp4netns
 ENV DOCKERD_ROOTLESS_ROOTLESSKIT_MTU 65520
-ENV DOCKERD_ENTRYPOINT_ARGS --add-runtime crun=/usr/local/bin/crun --default-runtime crun --experimental
+ENV DOCKERD_ENTRYPOINT_ARGS --add-runtime crun=/usr/local/bin/crun --default-runtime crun --experimental --registry-mirror=https://mirror.gcr.io
 
 ENTRYPOINT ["/sbin/init"]


### PR DESCRIPTION
On November 1st, Docker Hub will start to enforce pull rate limits:
- Free plan – anonymous users: 100 pulls per 6 hours 
- Free plan – authenticated users: 200 pulls per 6 hours
- Pro plan – unlimited
- Team plan – unlimited

To reduce the impact of this change, GCR will be set as the default registry mirror for the Docker Daemon. Similar action was taken by GitLab on their CI fleet: https://gitlab.com/gitlab-com/gl-infra/infrastructure/-/issues/3158#note_372525803.