### PR TITLE
dind: fix glue binary name

### DIFF
--- a/dind/init
+++ b/dind/init
@@ -9,7 +9,7 @@ set -ex
 
 
 # create iptables rules and use socat proxy to make containers reachable by their IPs
-/sbin/docker-iptables-glue &
+/sbin/dind &
 
 set -- ${DOCKERD_ENTRYPOINT_ARGS} "${@}"
 . /usr/local/bin/dockerd-entrypoint.sh "${@}"


### PR DESCRIPTION
The name of the binary follows the name of the go package. The package was renamed in the previous PR but I missed the init script.