### PR TITLE
close wire on runner deletion

### DIFF
--- a/operator/controllers/actionsrunner/reconciler.go
+++ b/operator/controllers/actionsrunner/reconciler.go
@@ -107,7 +107,10 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("actionsrunner", req.NamespacedName)
 
 	var actionsRunner inlocov1alpha1.ActionsRunner
-	if err := r.Get(ctx, req.NamespacedName, &actionsRunner); err != nil {
+	switch err := r.Get(ctx, req.NamespacedName, &actionsRunner); {
+	case apierrors.IsNotFound(err):
+		return ctrl.Result{}, r.wires.TryClose(&actionsRunner)
+	case err != nil:
 		return ctrl.Result{}, err
 	}
 

--- a/operator/controllers/actionsrunner/wire/collection.go
+++ b/operator/controllers/actionsrunner/wire/collection.go
@@ -86,3 +86,21 @@ func (c *Collection) WireFor(ctx context.Context, log logr.Logger, actionsRunner
 	c.wireRegistry[namespacedName] = wire
 	return wire, nil
 }
+
+func (c *Collection) TryClose(actionsRunner *inlocov1alpha1.ActionsRunner) error {
+	if actionsRunner == nil {
+		return errors.New("ActionsRunner == nil")
+	}
+
+	namespacedName := client.ObjectKey{
+		Namespace: actionsRunner.GetNamespace(),
+		Name:      actionsRunner.GetName(),
+	}
+
+	wire, ok := c.wireRegistry[namespacedName]
+	if !ok || wire.gone {
+		return nil
+	}
+
+	return wire.Close()
+}

--- a/operator/main.go
+++ b/operator/main.go
@@ -102,5 +102,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 }


### PR DESCRIPTION
Close wires when it is not possible to fetch its runner via K8s API. This will prevent zombie runners from acquiring locks for job consumption.