### PR TITLE
fix mismatching runner versions

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -2,7 +2,7 @@ IMAGE_NAME ?= inloco/kube-actions
 IMAGE_VERSION ?= $(shell git describe --dirty --broken --always)
 IMAGE_VARIANT ?= -operator
 
-AGENT_VERSION ?= 2.274.2
+AGENT_VERSION ?= 2.275.1
 
 # Default rule
 all: manager


### PR DESCRIPTION
For some unknown reason, the operator agent version was behind the actual runner version.