### PR TITLE
Fix Continuous Upgrade Workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,20 +4,23 @@ SHELL = /bin/bash
 dind/% operator/% runner/%:
 	$(MAKE) -C $(@D) $(@F)
 
+.ONESHELL:
 continuous-upgrade:
-	$(eval LATEST := $(shell curl -Lf https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name | ltrimstr("v")'))
-	exit $(.SHELLSTATUS)
-ifeq ($(shell sed -En 's/^RUNNER_VERSION \?= (.+)/\1/p' ./runner/Makefile), $(LATEST))
-	echo 'Everything up-to-date'
-else ifeq ($(shell git ls-remote --exit-code origin feat/actions-runner-v$(LATEST) >/dev/null)$(.SHELLSTATUS), 0)
-	echo 'Pending merge'
-else
-	sed -Ei 's/^AGENT_VERSION \?= .*/AGENT_VERSION ?= $(LATEST)/' ./operator/Makefile
-	sed -Ei 's/^RUNNER_VERSION \?= .*/RUNNER_VERSION ?= $(LATEST)/' ./runner/Makefile
-	git add -A
-	git commit -m 'feat: actions/runner#v$(LATEST)'
-	git checkout -b 'feat/actions-runner-v$(LATEST)'
-	git push -u "$$(git remote show)" "$$(git branch --show-current)"
-	gh pr create -t 'Actions Runner v$(LATEST)' -b 'https://github.com/actions/runner/releases/tag/v$(LATEST)'
-endif
+	@
+	export LATEST="$$(curl -Lf https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name | ltrimstr("v")')"
+	if ! sed -En "/^RUNNER_VERSION \?= $${LATEST}\$$/$$!{q1}" ./runner/Makefile
+	then
+		echo 'Everything up-to-date'
+	elif git ls-remote --exit-code "$$(git remote show)" "feat/actions-runner-v$${LATEST}"
+	then
+		echo 'Pending merge'
+	else
+		sed -Ei "s/^AGENT_VERSION \?= .*/AGENT_VERSION ?= $${LATEST}/" ./operator/Makefile
+		sed -Ei "s/^RUNNER_VERSION \?= .*/RUNNER_VERSION ?= $${LATEST}/" ./runner/Makefile
+		git add -A
+		git commit -m "feat: actions/runner#v$${LATEST}"
+		git checkout -b "feat/actions-runner-v$${LATEST}"
+		git push -u "$$(git remote show)" "$$(git branch --show-current)"
+		gh pr create -t "Actions Runner v$${LATEST}" -b "https://github.com/actions/runner/releases/tag/v$${LATEST}"
+	fi
 .PHONY: continuous-upgrade


### PR DESCRIPTION
Makefiles evaluate branch conditions upon reading the file and it was causing unexpected behaviors on the execution of the rule. This patch replaces make-branches with base-branches to solve the problem.