### PR TITLE
feat(runner): set env var to disable Gradle Daemon for Gradle-based projects

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -60,4 +60,7 @@ ENV DOCKER_BUILDKIT 0
 ENV DOCKER_CLI_EXPERIMENTAL enabled
 ENV RUNNER_ALLOW_RUNASROOT true
 
+# languages tools-specific
+ENV GRADLE_OPTS -Dorg.gradle.daemon=false
+
 ENTRYPOINT ["/sbin/init"]


### PR DESCRIPTION
From https://docs.gradle.org/current/userguide/gradle_daemon.html:

> Since Gradle 3.0, we enable Daemon by default and recommend using it for both developers' machines and Continuous Integration servers. However, if you suspect that Daemon makes your CI builds unstable, you can disable it to use a fresh runtime for each build since the runtime is completely isolated from any previous builds.