### PR TITLE
Remove OS/Arch references from AWS CLI zip name

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -33,8 +33,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     chmod 0755 /usr/local/bin/kubectl && \
     curl -Lfo /usr/local/bin/ec2-metadata http://s3.amazonaws.com/ec2metadata/ec2-metadata && \
     chmod 0755 /usr/local/bin/ec2-metadata && \
-    curl -Lfo /tmp/awscli-exe-linux-x86_64.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip && \
-    unzip /tmp/awscli-exe-linux-x86_64.zip -d /tmp && \
+    curl -Lfo /tmp/awscli2.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip && \
+    unzip /tmp/awscli2.zip -d /tmp && \
     /tmp/aws/install && \
     export ECRLOGIN_VERSION=$(curl -Lf https://api.github.com/repos/awslabs/amazon-ecr-credential-helper/releases/latest | jq -r '.tag_name' | sed 's/^v//g') && \
     curl -Lfo /usr/local/bin/docker-credential-ecr-login "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${ECRLOGIN_VERSION}/linux-amd64/docker-credential-ecr-login" && \


### PR DESCRIPTION
This will help when building the operator for multiple OS/Arch.