### PR TITLE
Fix upgrade workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ dind/% operator/% runner/%:
 .ONESHELL:
 continuous-upgrade:
 	@
-	export LATEST="$$(curl -Lf https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name | ltrimstr("v")')"
-	if ! sed -En "/^RUNNER_VERSION \?= $${LATEST}\$$/$$!{q1}" ./runner/Makefile
+	LATEST="$$(curl -Lf https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name | ltrimstr("v")')"
+	if grep -qE "^RUNNER_VERSION \?= $${LATEST}$$" ./runner/Makefile
 	then
 		echo 'Everything up-to-date'
 	elif git ls-remote --exit-code "$$(git remote show)" "feat/actions-runner-v$${LATEST}"


### PR DESCRIPTION
Upgrade workflow sometimes [fails](https://github.com/inloco/kube-actions/runs/2455603099). With this patch we can make sure the workflow won't continue if communication with Github's API fails, which is necessary to get the latest version of the runner).