### PR TITLE
fix(dind): don't exit on event error from dockerd, reconnect

### DIFF
--- a/dind/docker.go
+++ b/dind/docker.go
@@ -159,14 +159,13 @@ func (c *DockerClient) GetResourcesInfoFromEvents() (chan NetworkInfo, chan Cont
 		for {
 			msgs, errs := c.docker.Events(context.Background(), dockerTypes.EventsOptions{})
 
+		EventLoop:
 			for {
 				select {
 				case err := <-errs:
 					if err == io.EOF || err == nil {
-						c.logger.Println("EOF received from events channel, shutdown")
-						close(networks)
-						close(containers)
-						return
+						c.logger.Println("EOF received from events channel, reconnecting")
+						break EventLoop
 					}
 
 					c.logger.Printf("error from events channel: %+v\n", err)


### PR DESCRIPTION
This is an attempt to circumvent the occasional issues on `docker load` on "cd" runners.