### PR TITLE
Upgrade dind 20.x.x -> 23.0.5 and downgrade crun 1.18 -> 1.17.2

### DIFF
--- a/.github/workflows/continuous.yaml
+++ b/.github/workflows/continuous.yaml
@@ -23,19 +23,16 @@ jobs:
         run: make -C '${{ matrix.component }}' docker-build
       - name: aws configure
         uses: aws-actions/configure-aws-credentials@v2
-        if: github.ref == 'refs/heads/master'
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/ecr-public
       - name: docker login
-        if: github.ref == 'refs/heads/master'
         run: |
           docker login -u '${{ secrets.DOCKERHUB_USER }}' -p '${{ secrets.DOCKERHUB_PASS }}' docker.io
           docker login -u '${{ secrets.QUAY_USER }}' -p '${{ secrets.QUAY_PASS }}' quay.io
           docker login -u '${{ github.actor }}' -p '${{ github.token }}' ghcr.io
           docker login -u 'AWS' -p "$(aws ecr-public get-login-password)" public.ecr.aws
       - name: docker tag
-        if: github.ref == 'refs/heads/master'
         run: |
           make 'IMAGE_REGISTRY=docker.io' 'IMAGE_REPOSITORY=inloco/kube-actions' -C '${{ matrix.component }}' docker-tag
           make 'IMAGE_REGISTRY=quay.io' 'IMAGE_REPOSITORY=inloco/kube-actions' -C '${{ matrix.component }}' docker-tag
@@ -43,7 +40,6 @@ jobs:
           make 'IMAGE_REGISTRY=public.ecr.aws' 'IMAGE_REPOSITORY=incognia/kube-actions' -C '${{ matrix.component }}' docker-tag
       - name: docker push
         shell: '/usr/bin/env parallel --lb --retries 3 :::: {0}'
-        if: github.ref == 'refs/heads/master'
         run: |
           make 'IMAGE_REGISTRY=docker.io' 'IMAGE_REPOSITORY=inloco/kube-actions' -C '${{ matrix.component }}' docker-push
           make 'IMAGE_REGISTRY=quay.io' 'IMAGE_REPOSITORY=inloco/kube-actions' -C '${{ matrix.component }}' docker-push

--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -30,8 +30,8 @@ RUN apk add --no-cache jq socat fuse3 sudo shadow && \
 # Sounds a bit off to add root permission to rootless user, but its privileges are removed as soon as the container starts
 RUN echo '%wheel ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/wheel && \
     adduser rootless wheel && \
-    mkdir /run/user/1000 && \
-    chown -R rootless:rootless /home/rootless /run/user/1000/
+    mkdir /run/user/$(id -u rootless) && \
+    chown -R rootless:rootless /home/rootless /run/user/$(id -u rootless)/
 
 COPY --from=build /go/bin/dlv /usr/local/bin/dlv
 COPY --from=build /go/bin/dind /sbin/init

--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -1,6 +1,6 @@
 ARG DOCKER_VERSION
 
-FROM golang:1.19-alpine AS build
+FROM golang:1.20.4-alpine3.17 AS build
 RUN CGO_ENABLED=0 go install -v github.com/go-delve/delve/cmd/dlv@latest
 WORKDIR /go/src/github.com/inloco/kube-actions/dind
 COPY ./go.mod ./go.sum ./
@@ -10,7 +10,7 @@ RUN CGO_ENABLED=0 go install -a -gcflags 'all=-N -l' -ldflags '-d -extldflags "-
 
 FROM docker:${DOCKER_VERSION}-dind-rootless
 USER root
-RUN apk add --no-cache jq socat fuse3 && \
+RUN apk add --no-cache jq socat fuse3 sudo shadow && \
     export CRUN_URL=$(wget -qO- https://api.github.com/repos/containers/crun/releases | jq -r '.[0].assets[] | select(.name | match("linux-amd64$")) | .browser_download_url') && \
     wget -qO /usr/local/bin/crun ${CRUN_URL} && \
     chmod +x /usr/local/bin/crun && \
@@ -23,16 +23,22 @@ RUN apk add --no-cache jq socat fuse3 && \
     chown rootless:rootless /run/netns && \
     sed -i s/0.0.0.0/127.0.0.1/g $(which dockerd-entrypoint.sh) && \
     unlink /sbin/init && \
-    wget https://github.com/containers/fuse-overlayfs/releases/download/v1.7.1/fuse-overlayfs-x86_64 -O fuse-overlayfs && \
+    wget https://github.com/containers/fuse-overlayfs/releases/download/v1.11/fuse-overlayfs-x86_64 -O fuse-overlayfs && \
     chmod +x fuse-overlayfs && \
     cp fuse-overlayfs /usr/local/bin/fuse-overlayfs
+
+# Sounds a bit off to add root permission to rootless user, but its privileges are removed as soon as the container starts
+RUN echo '%wheel ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/wheel && \
+    adduser rootless wheel && \
+    mkdir /run/user/1000 && \
+    chown -R rootless:rootless /home/rootless /run/user/1000/
+
 COPY --from=build /go/bin/dlv /usr/local/bin/dlv
 COPY --from=build /go/bin/dind /sbin/init
-RUN chmod +s /sbin/init
 USER rootless
 ENV DOCKER_HOST=tcp://127.0.0.1:2375
 ENV DOCKER_TLS_CERTDIR=
 ENV DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns
 ENV DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=65520
 ENV DOCKERD_ENTRYPOINT_ARGS="--storage-driver fuse-overlayfs --add-runtime crun=/usr/local/bin/crun --default-runtime crun --experimental --registry-mirror https://mirror.gcr.io --tls=false"
-ENTRYPOINT ["/sbin/init"]
+ENTRYPOINT ["sudo", "-E", "/sbin/init"]

--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 go install -a -gcflags 'all=-N -l' -ldflags '-d -extldflags "-
 FROM docker:${DOCKER_VERSION}-dind-rootless
 USER root
 RUN apk add --no-cache jq socat fuse3 sudo shadow && \
-    export CRUN_URL=$(wget -qO- https://api.github.com/repos/containers/crun/releases | jq -r '.[0].assets[] | select(.name | match("linux-amd64$")) | .browser_download_url') && \
+    export CRUN_URL=https://github.com/containers/crun/releases/download/1.5/crun-1.5-linux-amd64 && \
     wget -qO /usr/local/bin/crun ${CRUN_URL} && \
     chmod +x /usr/local/bin/crun && \
     export SLIRP4NETNS_URL=$(wget -qO- https://api.github.com/repos/rootless-containers/slirp4netns/releases | jq -r '.[0].assets[] | select(.name | match("x86_64$")) | .browser_download_url') && \

--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 go install -a -gcflags 'all=-N -l' -ldflags '-d -extldflags "-
 FROM docker:${DOCKER_VERSION}-dind-rootless
 USER root
 RUN apk add --no-cache jq socat fuse3 sudo shadow && \
-    export CRUN_URL=https://github.com/containers/crun/releases/download/1.6/crun-1.6-linux-amd64 && \
+    export CRUN_URL=https://github.com/containers/crun/releases/download/1.7.2/crun-1.7.2-linux-amd64 && \
     wget -qO /usr/local/bin/crun ${CRUN_URL} && \
     chmod +x /usr/local/bin/crun && \
     export SLIRP4NETNS_URL=$(wget -qO- https://api.github.com/repos/rootless-containers/slirp4netns/releases | jq -r '.[0].assets[] | select(.name | match("x86_64$")) | .browser_download_url') && \

--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 go install -a -gcflags 'all=-N -l' -ldflags '-d -extldflags "-
 FROM docker:${DOCKER_VERSION}-dind-rootless
 USER root
 RUN apk add --no-cache jq socat fuse3 sudo shadow && \
-    export CRUN_URL=https://github.com/containers/crun/releases/download/1.5/crun-1.5-linux-amd64 && \
+    export CRUN_URL=https://github.com/containers/crun/releases/download/1.6/crun-1.6-linux-amd64 && \
     wget -qO /usr/local/bin/crun ${CRUN_URL} && \
     chmod +x /usr/local/bin/crun && \
     export SLIRP4NETNS_URL=$(wget -qO- https://api.github.com/repos/rootless-containers/slirp4netns/releases | jq -r '.[0].assets[] | select(.name | match("x86_64$")) | .browser_download_url') && \

--- a/dind/Makefile
+++ b/dind/Makefile
@@ -11,7 +11,7 @@ IMAGE_REPOSITORY ?= inloco/kube-actions
 IMAGE_VERSION ?= $(shell git describe --dirty --broken --always)
 IMAGE_VARIANT ?= -dind
 
-DOCKER_VERSION ?= 23.0.5 # this is the last version whose base is alpine:3.15, which has iptables version that is not picky with our setuid binary
+DOCKER_VERSION ?= 23.0.5
 
 docker: docker-build docker-tag docker-push
 	@printf '${BLD}${RED}make: *** [$@]${RST}${EOL}'

--- a/dind/Makefile
+++ b/dind/Makefile
@@ -11,7 +11,7 @@ IMAGE_REPOSITORY ?= inloco/kube-actions
 IMAGE_VERSION ?= $(shell git describe --dirty --broken --always)
 IMAGE_VARIANT ?= -dind
 
-DOCKER_VERSION ?= 20.10.15 # this is the last version whose base is alpine:3.15, which has iptables version that is not picky with our setuid binary
+DOCKER_VERSION ?= 23.0.5 # this is the last version whose base is alpine:3.15, which has iptables version that is not picky with our setuid binary
 
 docker: docker-build docker-tag docker-push
 	@printf '${BLD}${RED}make: *** [$@]${RST}${EOL}'

--- a/dind/docker.go
+++ b/dind/docker.go
@@ -72,9 +72,9 @@ func NewDockerClient(logger *log.Logger, cache *Cache) (*DockerClient, error) {
 	}, nil
 }
 
-func (c *DockerClient) PatchRuntimeDirs() error {
+func (c *DockerClient) PatchRuntimeDirs(userGid int) error {
 	for _, dir := range []string{"/var/lib/docker", "/home/rootless/.local/share/docker"} {
-		if err := os.Chown(dir, 1000, 1000); err != nil {
+		if err := os.Chown(dir, userGid, userGid); err != nil {
 			return err
 		}
 	}

--- a/dind/docker.go
+++ b/dind/docker.go
@@ -72,6 +72,16 @@ func NewDockerClient(logger *log.Logger, cache *Cache) (*DockerClient, error) {
 	}, nil
 }
 
+func (c *DockerClient) PatchRuntimeDirs() error {
+	for _, dir := range []string{"/var/lib/docker", "/home/rootless/.local/share/docker"} {
+		if err := os.Chown(dir, 1000, 1000); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (c *DockerClient) StartDockerd() (chan error, error) {
 	logger.Println("looking for dockerd-entrypoint.sh")
 	path, err := exec.LookPath("dockerd-entrypoint.sh")

--- a/dind/docker.go
+++ b/dind/docker.go
@@ -72,9 +72,9 @@ func NewDockerClient(logger *log.Logger, cache *Cache) (*DockerClient, error) {
 	}, nil
 }
 
-func (c *DockerClient) PatchRuntimeDirs(userGid int) error {
+func (c *DockerClient) PatchRuntimeDirs(uid, gid int) error {
 	for _, dir := range []string{"/var/lib/docker", "/home/rootless/.local/share/docker"} {
-		if err := os.Chown(dir, userGid, userGid); err != nil {
+		if err := os.Chown(dir, uid, gid); err != nil {
 			return err
 		}
 	}

--- a/dind/main.go
+++ b/dind/main.go
@@ -27,14 +27,19 @@ func main() {
 		logger.Panic(err)
 	}
 
-	logger.Println("removing rootless privileges")
-	if err := removeRootlessUserPrivileges(); err != nil {
-		logger.Panic(err)
-	}
-
 	logger.Println("creating docker client")
 	docker, err := NewDockerClient(logger, cache)
 	if err != nil {
+		logger.Panic(err)
+	}
+
+	logger.Println("patching runtime dirs")
+	if err := docker.PatchRuntimeDirs(); err != nil {
+		logger.Panic(err)
+	}
+
+	logger.Println("removing rootless privileges")
+	if err := removeRootlessUserPrivileges(); err != nil {
 		logger.Panic(err)
 	}
 

--- a/dind/main.go
+++ b/dind/main.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"os/user"
 	"syscall"
+	"strconv"
 
 	"github.com/coreos/go-iptables/iptables"
 )
@@ -34,7 +36,15 @@ func main() {
 	}
 
 	logger.Println("patching runtime dirs")
-	if err := docker.PatchRuntimeDirs(); err != nil {
+	rootlessUser, err := user.Lookup("rootless")
+	if err != nil {
+		logger.Panic(err)
+	}
+	rootlessUserGid, err := strconv.ParseInt(rootlessUser.Gid, 10, 64)
+	if err != nil {
+		logger.Panic(err)
+	}
+	if err := docker.PatchRuntimeDirs(int(rootlessUserGid)); err != nil {
 		logger.Panic(err)
 	}
 

--- a/dind/main.go
+++ b/dind/main.go
@@ -231,7 +231,7 @@ func removeRootlessUserPrivileges() error {
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 	}
-	if err := cmd.Start(); err != nil {
+	if err := cmd.Run(); err != nil {
 		return err
 	}
 

--- a/dind/main.go
+++ b/dind/main.go
@@ -40,11 +40,15 @@ func main() {
 	if err != nil {
 		logger.Panic(err)
 	}
-	rootlessUserGid, err := strconv.ParseInt(rootlessUser.Gid, 10, 64)
+	rootlessUid, err := strconv.Atoi(rootlessUser.Uid)
 	if err != nil {
 		logger.Panic(err)
 	}
-	if err := docker.PatchRuntimeDirs(int(rootlessUserGid)); err != nil {
+	rootlessGid, err := strconv.Atoi(rootlessUser.Gid)
+	if err != nil {
+		logger.Panic(err)
+	}
+	if err := docker.PatchRuntimeDirs(rootlessUid, rootlessGid); err != nil {
 		logger.Panic(err)
 	}
 


### PR DESCRIPTION
After we changed our container runtime from docker to containerd, a new error appeared:
failed to create shim task: OCI runtime create failed: mount_setattr `/sys`: Function not implemented: unknown

This PR has 3 changes:
- Upgrade dind image 20.x.x -> 23.0.5 cause we are very far behind! This was an attempt to fix the real issue, but it didn't worked. At least we are more updated now! After I upgraded this, a new error appeared when the golang app (which ran with set-guid-to-0) tried to use iptables. The issue happens because newer versions of iptaples block this type of usage to prevent privilege-escalation (From iptables docs: iptables will exit immediately with an error code of 111 if it finds that it was called as a setuid-to-root program. iptables cannot be used safely in this manner because it trusts the shared libraries (matches, targets) loaded at run time, the search path can be set using environment variables.). To fix this issue, I've changed the rootless user to have sudo access when the container starts, removing it just after the golang app boots with sudo. That way, the golang app gets sudo (until its alive) and the rootless user don't. @laurovenancio @lucasinloco.
- Downgrading crun 1.18 -> 1.17.2 following this issue: https://github.com/containers/crun/issues/1131
- Upgrade fuse-overlayfs 1.7.x -> 1.11

I made the decision of wait AWS EKS to upgrade its kernel to at least 5.12 until the end of year. If It doesn´t happen, we will migrate out of crun in favor of the default runc.