### PR TITLE
dind: update docker version

### DIFF
--- a/dind/Makefile
+++ b/dind/Makefile
@@ -11,7 +11,7 @@ IMAGE_REPOSITORY ?= inloco/kube-actions
 IMAGE_VERSION ?= $(shell git describe --dirty --broken --always)
 IMAGE_VARIANT ?= -dind
 
-DOCKER_VERSION ?= 23.0.5
+DOCKER_VERSION ?= 24.0
 
 docker: docker-build docker-tag docker-push
 	@printf '${BLD}${RED}make: *** [$@]${RST}${EOL}'


### PR DESCRIPTION
> kube-actions[dind]: 2023/07/27 18:39:50 error from events channel: Error response from daemon: client version 1.43 is too new. Maximum supported API version is 1.42