### PR TITLE
Kustomization refresh, add pre-pull daemon-set (moved from sre-cd)

### DIFF
--- a/operator/config/crd/kustomization.yaml
+++ b/operator/config/crd/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
@@ -5,16 +8,16 @@ resources:
 - bases/inloco.com.br_actionsrunners.yaml
 - bases/inloco.com.br_actionsrunnerjobs.yaml
 - bases/inloco.com.br_actionsrunnerreplicasets.yaml
-#+kubebuilder:scaffold:crdkustomizeresource
-
-patchesStrategicMerge:
-# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
-# patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_actionsrunners.yaml
-#- patches/cainjection_in_actionsrunnerjobs.yaml
-#- patches/cainjection_in_actionsrunnerreplicasets.yaml
-#+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml
+
+patches:
+- path: patches/cainjection_in_actionsrunners.yaml
+#+kubebuilder:scaffold:crdkustomizeresource
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+#- path: patches/cainjection_in_actionsrunnerjobs.yaml
+#- path: patches/cainjection_in_actionsrunnerreplicasets.yaml
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch

--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -1,40 +1,44 @@
 namespace: kube-actions
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
 - ../webhook
 - ../certmanager
 
-patchesStrategicMerge:
-- manager_webhook_patch.yaml
-- webhookcainjection_patch.yaml
 
 vars:
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+- fieldref:
+    fieldPath: metadata.namespace
+  name: CERTIFICATE_NAMESPACE
   objref:
-    kind: Certificate
     group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
     version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
+- fieldref: {}
+  name: CERTIFICATE_NAME
   objref:
-    kind: Certificate
     group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
     version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-- name: SERVICE_NAMESPACE
+- fieldref:
+    fieldPath: metadata.namespace
+  name: SERVICE_NAMESPACE
   objref:
     kind: Service
-    version: v1
     name: webhook-service
-  fieldref:
-    fieldpath: metadata.namespace
-- name: SERVICE_NAME
+    version: v1
+- fieldref: {}
+  name: SERVICE_NAME
   objref:
     kind: Service
-    version: v1
     name: webhook-service
+    version: v1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: manager_webhook_patch.yaml
+- path: webhookcainjection_patch.yaml

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - --max-concurrent-reconciles=1000
         - --metrics-bind-address=:9102
-        image: inloco/kube-actions
+        image: incognia/kube-actions
         name: manager
         envFrom:
         - configMapRef:

--- a/operator/k8s/development/kustomization.yaml
+++ b/operator/k8s/development/kustomization.yaml
@@ -1,6 +1,5 @@
-bases:
-- ../../config/default
 resources:
+- ../../config/default
 - configmap.yaml
 generators:
 - secret.yaml

--- a/operator/k8s/production/docker-pull.daemonset.yaml
+++ b/operator/k8s/production/docker-pull.daemonset.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: docker-pull
+  labels:
+    app.kubernetes.io/name: kube-actions
+    app.kubernetes.io/component: docker-pull
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-actions
+      app.kubernetes.io/component: docker-pull
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-actions
+        app.kubernetes.io/component: docker-pull
+    spec:
+      containers:
+        - name: pause
+          image: k8s.gcr.io/pause
+      initContainers:
+        - name: docker-pull-runner
+          image: incognia/kube-actions-runner
+          command:
+            - dlv
+          args:
+            - version
+        - name: docker-pull-operator
+          image: incognia/kube-actions-operator
+          command:
+            - dlv
+          args:
+            - version
+        - name: docker-pull-dind
+          image: incognia/kube-actions-dind
+          command:
+            - dlv
+          args:
+            - version

--- a/operator/k8s/production/kustomization.yaml
+++ b/operator/k8s/production/kustomization.yaml
@@ -3,10 +3,20 @@ kind: Kustomization
 namespace: kube-actions
 resources:
 - ../../config/default
+- ./docker-pull.daemonset.yaml
 - ./configmap.yaml
 generators:
 - ./secret.yaml
 images:
-- name: inloco/kube-actions
+- name: incognia/kube-actions
   newName: public.ecr.aws/incognia/kube-actions
   newTag: dbd5cc0-operator
+- name: incognia/kube-actions-operator
+  newName: public.ecr.aws/incognia/kube-actions
+  newTag: dbd5cc0-operator
+- name: incognia/kube-actions-runner
+  newName: public.ecr.aws/incognia/kube-actions
+  newTag: dbd5cc0-runner
+- name: incognia/kube-actions-dind
+  newName: public.ecr.aws/incognia/kube-actions
+  newTag: dbd5cc0-dind

--- a/operator/k8s/production/kustomization.yaml
+++ b/operator/k8s/production/kustomization.yaml
@@ -1,12 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-actions
-bases:
-  - ../../config/default
 resources:
-  - ./configmap.yaml
+- ../../config/default
+- ./configmap.yaml
 generators:
-  - ./secret.yaml
+- ./secret.yaml
 images:
 - name: inloco/kube-actions
   newName: public.ecr.aws/incognia/kube-actions


### PR DESCRIPTION
* As alterações de sintaxe do kustomization foram feitas pelo `kustomize edit fix`.
* O daemon-set de pre-pull foi movido do sre-cd. Isso centraliza a definição das versões no mesmo repo.