### PR TITLE
Reduce the Registration and Removal tokens ttl to 20min

### DIFF
--- a/operator/internal/controller/actionsrunner/facades/gh.go
+++ b/operator/internal/controller/actionsrunner/facades/gh.go
@@ -100,10 +100,10 @@ var (
 	githubRepositories       = cache.New(time.Hour, time.Hour)
 	githubRepositoriesMutext sync.Mutex
 
-	githubRegistrationTokens       = cache.New(time.Hour, time.Hour)
+	githubRegistrationTokens       = cache.New(20*time.Minute, 20*time.Minute)
 	githubRegistrationTokensMutext sync.Mutex
 
-	githubRemoveTokens       = cache.New(time.Hour, time.Hour)
+	githubRemoveTokens       = cache.New(20*time.Minute, 20*time.Minute))
 	githubRemoveTokensMutext sync.Mutex
 
 	githubTenantCredentials       = cache.New(time.Hour, time.Hour)

--- a/operator/internal/controller/actionsrunner/facades/gh.go
+++ b/operator/internal/controller/actionsrunner/facades/gh.go
@@ -103,7 +103,7 @@ var (
 	githubRegistrationTokens       = cache.New(20*time.Minute, 20*time.Minute)
 	githubRegistrationTokensMutext sync.Mutex
 
-	githubRemoveTokens       = cache.New(20*time.Minute, 20*time.Minute))
+	githubRemoveTokens       = cache.New(20*time.Minute, 20*time.Minute)
 	githubRemoveTokensMutext sync.Mutex
 
 	githubTenantCredentials       = cache.New(time.Hour, time.Hour)


### PR DESCRIPTION
This is an attempt to fix the runners using expired tokens issue, based on the Github ticket response.